### PR TITLE
Day 2: Add EDA overview template

### DIFF
--- a/notebooks/01_eda.ipynb
+++ b/notebooks/01_eda.ipynb
@@ -387,7 +387,17 @@
    "source": [
     "## Key Observations (EDA Summary)\n",
     "\n",
-    "- Class imbalance observed in the target variable"
+    "- The dataset contains 7,043 rows and 21 columns, with no missing values.\n",
+    "- The target variable (Churn) is imbalanced, with approximately 73% non-churned\n",
+    "  customers and 27% churned customers.\n",
+    "- Most features are stored as object (categorical) types, including many binary\n",
+    "  Yes/No features.\n",
+    "- Several categorical features include a third category such as\n",
+    "  \"No internet service\", which should be handled carefully during encoding.\n",
+    "- The TotalCharges feature is stored as an object type despite representing\n",
+    "  numerical values and will require type conversion.\n",
+    "- Binary categorical features (Yes/No) can be safely encoded as 0/1 to reduce\n",
+    "  memory usage and simplify modeling."
    ]
   },
   {

--- a/notebooks/01_eda.ipynb
+++ b/notebooks/01_eda.ipynb
@@ -1,0 +1,440 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "05bbaafd",
+   "metadata": {},
+   "source": [
+    "# Exploratory Data Analysis (EDA) – Overview\n",
+    "\n",
+    "This notebook serves as the **central EDA reference** for the project.\n",
+    "\n",
+    "Purpose:\n",
+    "- Provide a shared understanding of the dataset\n",
+    "- Summarize key structural and quality observations\n",
+    "- Act as a reference for all detailed EDA notebooks\n",
+    "\n",
+    "Detailed analyses are implemented in separate notebooks such as:\n",
+    "- 02_univariate_analysis.ipynb\n",
+    "- 03_correlation_analysis.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "3a1d5e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add project root to PYTHONPATH\n",
+    "project_root = Path().resolve().parent\n",
+    "sys.path.append(str(project_root))\n",
+    "\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from src.utils.config import PROCESSED_DATA_PATH\n",
+    "\n",
+    "plt.style.use(\"default\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8a5ed56c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>customerID</th>\n",
+       "      <th>gender</th>\n",
+       "      <th>SeniorCitizen</th>\n",
+       "      <th>Partner</th>\n",
+       "      <th>Dependents</th>\n",
+       "      <th>tenure</th>\n",
+       "      <th>PhoneService</th>\n",
+       "      <th>MultipleLines</th>\n",
+       "      <th>InternetService</th>\n",
+       "      <th>OnlineSecurity</th>\n",
+       "      <th>...</th>\n",
+       "      <th>DeviceProtection</th>\n",
+       "      <th>TechSupport</th>\n",
+       "      <th>StreamingTV</th>\n",
+       "      <th>StreamingMovies</th>\n",
+       "      <th>Contract</th>\n",
+       "      <th>PaperlessBilling</th>\n",
+       "      <th>PaymentMethod</th>\n",
+       "      <th>MonthlyCharges</th>\n",
+       "      <th>TotalCharges</th>\n",
+       "      <th>Churn</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7590-VHVEG</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>No</td>\n",
+       "      <td>1</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No phone service</td>\n",
+       "      <td>DSL</td>\n",
+       "      <td>No</td>\n",
+       "      <td>...</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>Month-to-month</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>Electronic check</td>\n",
+       "      <td>29.85</td>\n",
+       "      <td>29.85</td>\n",
+       "      <td>No</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5575-GNVDE</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>34</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>No</td>\n",
+       "      <td>DSL</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>...</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>One year</td>\n",
+       "      <td>No</td>\n",
+       "      <td>Mailed check</td>\n",
+       "      <td>56.95</td>\n",
+       "      <td>1889.5</td>\n",
+       "      <td>No</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3668-QPYBK</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>No</td>\n",
+       "      <td>DSL</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>...</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>Month-to-month</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>Mailed check</td>\n",
+       "      <td>53.85</td>\n",
+       "      <td>108.15</td>\n",
+       "      <td>Yes</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7795-CFOCW</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>45</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No phone service</td>\n",
+       "      <td>DSL</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>...</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>One year</td>\n",
+       "      <td>No</td>\n",
+       "      <td>Bank transfer (automatic)</td>\n",
+       "      <td>42.30</td>\n",
+       "      <td>1840.75</td>\n",
+       "      <td>No</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>9237-HQITU</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>0</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>No</td>\n",
+       "      <td>Fiber optic</td>\n",
+       "      <td>No</td>\n",
+       "      <td>...</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>No</td>\n",
+       "      <td>Month-to-month</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>Electronic check</td>\n",
+       "      <td>70.70</td>\n",
+       "      <td>151.65</td>\n",
+       "      <td>Yes</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 21 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   customerID  gender  SeniorCitizen Partner Dependents  tenure PhoneService  \\\n",
+       "0  7590-VHVEG  Female              0     Yes         No       1           No   \n",
+       "1  5575-GNVDE    Male              0      No         No      34          Yes   \n",
+       "2  3668-QPYBK    Male              0      No         No       2          Yes   \n",
+       "3  7795-CFOCW    Male              0      No         No      45           No   \n",
+       "4  9237-HQITU  Female              0      No         No       2          Yes   \n",
+       "\n",
+       "      MultipleLines InternetService OnlineSecurity  ... DeviceProtection  \\\n",
+       "0  No phone service             DSL             No  ...               No   \n",
+       "1                No             DSL            Yes  ...              Yes   \n",
+       "2                No             DSL            Yes  ...               No   \n",
+       "3  No phone service             DSL            Yes  ...              Yes   \n",
+       "4                No     Fiber optic             No  ...               No   \n",
+       "\n",
+       "  TechSupport StreamingTV StreamingMovies        Contract PaperlessBilling  \\\n",
+       "0          No          No              No  Month-to-month              Yes   \n",
+       "1          No          No              No        One year               No   \n",
+       "2          No          No              No  Month-to-month              Yes   \n",
+       "3         Yes          No              No        One year               No   \n",
+       "4          No          No              No  Month-to-month              Yes   \n",
+       "\n",
+       "               PaymentMethod MonthlyCharges  TotalCharges Churn  \n",
+       "0           Electronic check          29.85         29.85    No  \n",
+       "1               Mailed check          56.95        1889.5    No  \n",
+       "2               Mailed check          53.85        108.15   Yes  \n",
+       "3  Bank transfer (automatic)          42.30       1840.75    No  \n",
+       "4           Electronic check          70.70        151.65   Yes  \n",
+       "\n",
+       "[5 rows x 21 columns]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path = PROCESSED_DATA_PATH / \"telco_customer_churn_validated.csv\"\n",
+    "df = pd.read_csv(data_path)\n",
+    "\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e485f5ab",
+   "metadata": {},
+   "source": [
+    "## Dataset Structure\n",
+    "\n",
+    "This section provides a high-level overview of the dataset structure\n",
+    "and basic data integrity checks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "69eb2b31",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((7043, 21),\n",
+       " Index(['customerID', 'gender', 'SeniorCitizen', 'Partner', 'Dependents',\n",
+       "        'tenure', 'PhoneService', 'MultipleLines', 'InternetService',\n",
+       "        'OnlineSecurity', 'OnlineBackup', 'DeviceProtection', 'TechSupport',\n",
+       "        'StreamingTV', 'StreamingMovies', 'Contract', 'PaperlessBilling',\n",
+       "        'PaymentMethod', 'MonthlyCharges', 'TotalCharges', 'Churn'],\n",
+       "       dtype='object'))"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape, df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "957d7338",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 7043 entries, 0 to 7042\n",
+      "Data columns (total 21 columns):\n",
+      " #   Column            Non-Null Count  Dtype  \n",
+      "---  ------            --------------  -----  \n",
+      " 0   customerID        7043 non-null   object \n",
+      " 1   gender            7043 non-null   object \n",
+      " 2   SeniorCitizen     7043 non-null   int64  \n",
+      " 3   Partner           7043 non-null   object \n",
+      " 4   Dependents        7043 non-null   object \n",
+      " 5   tenure            7043 non-null   int64  \n",
+      " 6   PhoneService      7043 non-null   object \n",
+      " 7   MultipleLines     7043 non-null   object \n",
+      " 8   InternetService   7043 non-null   object \n",
+      " 9   OnlineSecurity    7043 non-null   object \n",
+      " 10  OnlineBackup      7043 non-null   object \n",
+      " 11  DeviceProtection  7043 non-null   object \n",
+      " 12  TechSupport       7043 non-null   object \n",
+      " 13  StreamingTV       7043 non-null   object \n",
+      " 14  StreamingMovies   7043 non-null   object \n",
+      " 15  Contract          7043 non-null   object \n",
+      " 16  PaperlessBilling  7043 non-null   object \n",
+      " 17  PaymentMethod     7043 non-null   object \n",
+      " 18  MonthlyCharges    7043 non-null   float64\n",
+      " 19  TotalCharges      7043 non-null   object \n",
+      " 20  Churn             7043 non-null   object \n",
+      "dtypes: float64(1), int64(2), object(18)\n",
+      "memory usage: 1.1+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62e0e292",
+   "metadata": {},
+   "source": [
+    "## Target Variable: Churn\n",
+    "\n",
+    "This section provides an initial overview of the target variable.\n",
+    "Detailed analysis is performed in `04_feature_target_analysis.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f47e2bdd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Churn\n",
+       "No     0.73463\n",
+       "Yes    0.26537\n",
+       "Name: proportion, dtype: float64"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[\"Churn\"].value_counts(normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8595eef",
+   "metadata": {},
+   "source": [
+    "## Key Observations (EDA Summary)\n",
+    "\n",
+    "Use this section to record **shared observations** agreed upon by the team.\n",
+    "\n",
+    "Examples:\n",
+    "- Class imbalance observed in the target variable\n",
+    "- Presence of categorical features with \"No internet service\"\n",
+    "- Potential data type issues (e.g., TotalCharges)\n",
+    "\n",
+    "This section should be updated collaboratively.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71c0ddf4",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "502c7429",
+   "metadata": {},
+   "source": [
+    "## Related Analysis Notebooks\n",
+    "\n",
+    "- Univariate Analysis: `02_univariate_analysis.ipynb`\n",
+    "- Correlation Analysis: `03_correlation_analysis.ipynb`\n",
+    "- Feature–Target Relationships: `04_feature_target_analysis.ipynb`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.11.9)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/01_eda.ipynb
+++ b/notebooks/01_eda.ipynb
@@ -387,21 +387,8 @@
    "source": [
     "## Key Observations (EDA Summary)\n",
     "\n",
-    "Use this section to record **shared observations** agreed upon by the team.\n",
-    "\n",
-    "Examples:\n",
-    "- Class imbalance observed in the target variable\n",
-    "- Presence of categorical features with \"No internet service\"\n",
-    "- Potential data type issues (e.g., TotalCharges)\n",
-    "\n",
-    "This section should be updated collaboratively.\n"
+    "- Class imbalance observed in the target variable"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "71c0ddf4",
-   "metadata": {},
-   "source": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR adds the initial Exploratory Data Analysis (EDA) overview notebook.

Changes included:
- Added `01_eda.ipynb` as a central EDA reference notebook.
- Defined the purpose of the EDA overview as a shared, high-level reference
  for understanding the dataset structure and quality.
- Linked the overview notebook to upcoming detailed EDA notebooks
  (univariate analysis, correlation analysis, and feature–target analysis).

Note:
This notebook is intentionally lightweight and does not include detailed analysis.
All in-depth EDA will be implemented in separate notebooks as part of upcomming asks.

Closes #11 